### PR TITLE
Nesting, Auto Labeling, Marking as Important

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This is a Google Apps Script that updates Gmail labels for GitHub notification m
 1. Go to [script.google.com](https://script.google.com). It will automatically create a new script. Paste in this script from UpdateLabels.gs.
 2. Edit the CUSTOM_MAPPING variable to establish a mapping between GitHub issue labels and Gmail labels.
 3. Add the Gmail labels that you want to be marked as important in the MARK_IMPORTANT list. (note these are the Gmail labels and not the GitHub labels)
-3. Set either to use a strict_mode or not, if not using strict_mode: All other labels will be mapped as is under a project label.
-4. (Optional, but recommended) [Create a GitHub access token](https://github.com/settings/tokens/new) and paste its value into the ACCESS_TOKEN variable. This will increase the rate limit on API calls.
-5. Name and save your script.
-6. [Install a time-driven trigger](https://developers.google.com/apps-script/guides/triggers/installable#managing_triggers_manually) by clicking on the clock button, clicking "Click here to add one now", and configuring how often you want the script to run.
+4. Set either to use a strict_mode or not, if not using strict_mode: All other labels will be mapped as is under a project label.
+5. (Optional, but recommended) [Create a GitHub access token](https://github.com/settings/tokens/new) and paste its value into the ACCESS_TOKEN variable. This will increase the rate limit on API calls.
+6. Name and save your script.
+7. [Install a time-driven trigger](https://developers.google.com/apps-script/guides/triggers/installable#managing_triggers_manually) by clicking on the clock button, clicking "Click here to add one now", and configuring how often you want the script to run.
 
 ## Future work
 I haven't had time to look at the way apps scripts are published to make this installable, and whether it could be configurable if it was installable.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ This is a Google Apps Script that updates Gmail labels for GitHub notification m
 
 ## Setup
 1. Go to [script.google.com](https://script.google.com). It will automatically create a new script. Paste in this script from UpdateLabels.gs.
-2. Edit the LABEL_MAPPING variable to establish a mapping between GitHub issue labels and Gmail labels.
+2. Edit the CUSTOM_MAPPING variable to establish a mapping between GitHub issue labels and Gmail labels. All other labels will be mapped as is under a project label.
 3. (Optional, but recommended) [Create a GitHub access token](https://github.com/settings/tokens/new) and paste its value into the ACCESS_TOKEN variable. This will increase the rate limit on API calls.
 4. Name and save your script.
 5. [Install a time-driven trigger](https://developers.google.com/apps-script/guides/triggers/installable#managing_triggers_manually) by clicking on the clock button, clicking "Click here to add one now", and configuring how often you want the script to run.

--- a/README.md
+++ b/README.md
@@ -3,10 +3,12 @@ This is a Google Apps Script that updates Gmail labels for GitHub notification m
 
 ## Setup
 1. Go to [script.google.com](https://script.google.com). It will automatically create a new script. Paste in this script from UpdateLabels.gs.
-2. Edit the CUSTOM_MAPPING variable to establish a mapping between GitHub issue labels and Gmail labels. All other labels will be mapped as is under a project label.
-3. (Optional, but recommended) [Create a GitHub access token](https://github.com/settings/tokens/new) and paste its value into the ACCESS_TOKEN variable. This will increase the rate limit on API calls.
-4. Name and save your script.
-5. [Install a time-driven trigger](https://developers.google.com/apps-script/guides/triggers/installable#managing_triggers_manually) by clicking on the clock button, clicking "Click here to add one now", and configuring how often you want the script to run.
+2. Edit the CUSTOM_MAPPING variable to establish a mapping between GitHub issue labels and Gmail labels.
+3. Add the Gmail labels that you want to be marked as important in the MARK_IMPORTANT list. (note these are the Gmail labels and not the GitHub labels)
+3. Set either to use a strict_mode or not, if not using strict_mode: All other labels will be mapped as is under a project label.
+4. (Optional, but recommended) [Create a GitHub access token](https://github.com/settings/tokens/new) and paste its value into the ACCESS_TOKEN variable. This will increase the rate limit on API calls.
+5. Name and save your script.
+6. [Install a time-driven trigger](https://developers.google.com/apps-script/guides/triggers/installable#managing_triggers_manually) by clicking on the clock button, clicking "Click here to add one now", and configuring how often you want the script to run.
 
 ## Future work
 I haven't had time to look at the way apps scripts are published to make this installable, and whether it could be configurable if it was installable.

--- a/UpdateLabels.gs
+++ b/UpdateLabels.gs
@@ -88,9 +88,9 @@ function updateNewGithubNotificationThreadLabels() {
       for (var j = 0; j < labels.length; j++) {
         var labelName = CUSTOM_MAPPING[labels[j]['name']] ?
                         CUSTOM_MAPPING[labels[j]['name']] : labels[j]['name'];
-        if (!labelName && strict_mode)
-          continue;
-        else {
+        if (!labelName) {
+          if (strict_mode)
+            continue;
           var projectName = CUSTOM_MAPPING[project] ?
                             CUSTOM_MAPPING[project] : project;
           getOrCreateLabel(projectName);

--- a/UpdateLabels.gs
+++ b/UpdateLabels.gs
@@ -92,9 +92,9 @@ function updateNewGithubNotificationThreadLabels() {
       // https://developer.github.com/v3/issues/#get-a-single-issue
       // And it could potentially take more actions on the thread in Gmail, like
       // archiving or changing read/important state. The full API for the thread
--     // is documented here:
--     // https://developers.google.com/apps-script/reference/gmail/gmail-thread
--     // and there is also an API for individual messages documented here:
+      // is documented here:
+      // https://developers.google.com/apps-script/reference/gmail/gmail-thread
+      // and there is also an API for individual messages documented here:
       // https://developers.google.com/apps-script/reference/gmail/gmail-message
       var issueInfo = JSON.parse(response.getContentText());
       var labels = issueInfo['labels'];

--- a/UpdateLabels.gs
+++ b/UpdateLabels.gs
@@ -91,7 +91,11 @@ function updateNewGithubNotificationThreadLabels() {
       // here:
       // https://developer.github.com/v3/issues/#get-a-single-issue
       // And it could potentially take more actions on the thread in Gmail, like
-      // archiving or changing read/important state.
+      // archiving or changing read/important state. The full API for the thread
+-     // is documented here:
+-     // https://developers.google.com/apps-script/reference/gmail/gmail-thread
+-     // and there is also an API for individual messages documented here:
+      // https://developers.google.com/apps-script/reference/gmail/gmail-message
       var issueInfo = JSON.parse(response.getContentText());
       var labels = issueInfo['labels'];
       for (var j = 0; j < labels.length; j++) {

--- a/UpdateLabels.gs
+++ b/UpdateLabels.gs
@@ -49,7 +49,6 @@ function updateNewGithubNotificationThreadLabels() {
   var threads = GmailApp.search('from:notifications@github.com newer_than:1d');
   var seenThreads = JSON.parse(
       PropertiesService.getUserProperties().getProperty('seenThreads') || '{}');
-  var seenThreads = {};
   for (var i = 0; i < threads.length; i++) {
     // Check if this thread has been processed before and update the cache.
     var threadId = threads[i].getId();

--- a/UpdateLabels.gs
+++ b/UpdateLabels.gs
@@ -46,9 +46,9 @@ function updateNewGithubNotificationThreadLabels() {
   // since it last ran. So we do a search for GitHub notification mails from the
   // last day, and store a property with info about the ones that haven't
   // changed.
-  var threads = GmailApp.search('from:notifications@github.com newer_than:60d');
-  //var seenThreads = JSON.parse(
-  //    PropertiesService.getUserProperties().getProperty('seenThreads') || '{}');
+  var threads = GmailApp.search('from:notifications@github.com newer_than:1d');
+  var seenThreads = JSON.parse(
+      PropertiesService.getUserProperties().getProperty('seenThreads') || '{}');
   var seenThreads = {};
   for (var i = 0; i < threads.length; i++) {
     // Check if this thread has been processed before and update the cache.


### PR DESCRIPTION
I have added 
1- Nesting, which would work nice if someone is managing multiple GitHub projects (or just one).
2- It would optionally label all labels, not just the ones that are specified explicitly (nested under the project name)
3- Added another list to mark thread with some labels as important.
